### PR TITLE
Remove leading zeros from days, and hours

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -15,7 +15,7 @@ build:
           ./glide --version
     - script:
         name: update version
-        code: export VERSION=$(date +%Y.%j.%H%M)
+        code: export VERSION=$(date +%Y.%-j.%-H%M)
     - termie/bash-template
     - script:
         name: prune


### PR DESCRIPTION
Leading zeros are invalid for semver.

Also, please do not use this versioning scheme for future wercker steps:

Having the major version increment indicates a backwards incompatible change. Currently there is no way of doing this. Plus it happens every year, for no reason.